### PR TITLE
Avoid pointer allocations for encoding rows

### DIFF
--- a/params.go
+++ b/params.go
@@ -80,7 +80,7 @@ func (p *raptorParams) getDegree(v uint32) uint32 {
 	panic("should be unreachable")
 }
 
-func (p *raptorParams) calcEncodingRow(x uint32) *encodingRow {
+func (p *raptorParams) calcEncodingRow(x uint32) encodingRow {
 	ja := 53591 + p._J*997
 	if ja%2 == 0 {
 		ja++
@@ -103,7 +103,7 @@ func (p *raptorParams) calcEncodingRow(x uint32) *encodingRow {
 	a1 := 1 + random(x, 4, p._P1-1)
 	b1 := random(x, 5, p._P1)
 
-	return &encodingRow{
+	return encodingRow{
 		d:  d,
 		a:  a,
 		b:  b,
@@ -183,7 +183,8 @@ func (r *encodingRow) encodeGen(m, relaxed *discmath.MatrixGF256, p *raptorParam
 
 func (p *raptorParams) genSymbol(relaxed *discmath.MatrixGF256, symbolSz, id uint32) []byte {
 	m := discmath.NewMatrixGF256(1, symbolSz)
-	p.calcEncodingRow(id).encodeGen(m, relaxed, p)
+	row := p.calcEncodingRow(id)
+	row.encodeGen(m, relaxed, p)
 
 	return m.GetRow(0)
 }

--- a/solver.go
+++ b/solver.go
@@ -25,9 +25,9 @@ func (p *raptorParams) createD(symbols []Symbol) *discmath.MatrixGF256 {
 func (p *raptorParams) Solve(symbols []Symbol) (*discmath.MatrixGF256, error) {
 	d := p.createD(symbols)
 
-	eRows := make([]*encodingRow, 0, len(symbols))
-	for _, symbol := range symbols {
-		eRows = append(eRows, p.calcEncodingRow(symbol.ID))
+	eRows := make([]encodingRow, len(symbols))
+	for i, symbol := range symbols {
+		eRows[i] = p.calcEncodingRow(symbol.ID)
 	}
 
 	aUpper := discmath.NewMatrixGF256(p._S+uint32(len(eRows)), p._L)
@@ -58,8 +58,8 @@ func (p *raptorParams) Solve(symbols []Symbol) (*discmath.MatrixGF256, error) {
 	}
 
 	// Encode
-	for ri, row := range eRows {
-		row.encode(aUpper, uint32(ri), p)
+	for ri := range eRows {
+		eRows[ri].encode(aUpper, uint32(ri), p)
 	}
 
 	uSize, rowPermutation, colPermutation := inactivateDecode(aUpper, p._P)


### PR DESCRIPTION
## Summary
- Return encodingRow structs by value instead of pointers to reduce heap allocations
- Use value slices in Solve and adjust genSymbol accordingly

## Testing
- `go test ./...`
- `go test -bench=. -benchmem`


------
https://chatgpt.com/codex/tasks/task_e_68a2bc058b0c8320bfac21c0e23a7eb4